### PR TITLE
Remove module.exports.db

### DIFF
--- a/truffle-config.js
+++ b/truffle-config.js
@@ -92,8 +92,8 @@ module.exports = {
       //  evmVersion: "byzantium"
       // }
     }
-  } /*,
+  },
   db: {
-    enabled: true
-  } */
+    enabled: false
+  }
 };

--- a/truffle-config.js
+++ b/truffle-config.js
@@ -92,8 +92,8 @@ module.exports = {
       //  evmVersion: "byzantium"
       // }
     }
-  },
+  } /*,
   db: {
     enabled: true
-  }
+  } */
 };

--- a/truffle-config.ovm.js
+++ b/truffle-config.ovm.js
@@ -3,7 +3,8 @@
 require('dotenv').config();
 const ganacheMnemonic = process.env["GANACHE_MNEMONIC"];
 const kovanMnemonic = process.env["KOVAN_MNEMONIC"];
-const mnemonic = process.env["MNEMONIC"];
+const mnemonic = 'test test test test test test test test test test test junk' // process.env["MNEMONIC"];
+
 const infuraKey = process.env["INFURA_KEY"];
 
 //uncomment to use mainnetMnemonic, be sure to set it in the .env file
@@ -91,6 +92,6 @@ module.exports = {
     },
   },
   db: {
-    enabled: true
+    enabled: false
   }
 }


### PR DESCRIPTION
1. Put the mnemonic for `optimistic_ethereum` in this file. It is not a secret, so there is no reason to hide it. For usability reasons, it is much better to have it in a file that developers get when they clone the repository rather than require them to add it manually.

2. Disabled `module.exports.db` in both configuration files.

This solves #9