### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,8 +98,8 @@ This script lets Truffle know to use the `truffle-config.ovm.js` configuration f
 Please note: the optimistic `solc` compiler we have included relies on the latest version of the package, and currently uses *version 0.7.6*. If you would like to use a different version of `solc`, see the available optimistic versions [here](https://www.npmjs.com/package/@eth-optimism/solc), and run:
 
 ```
- npm install @eth-optimism/solc@<YourVersion>
- ```
+npm install @eth-optimism/solc@<YourVersion>
+```
 
 You can double check that you have the version you want by looking at the `package.json` dependencies in this project.
 


### PR DESCRIPTION
This typo creates problem when you try to build the `index.md` file for the documentation. You can see the error just few line under the [Compiling section](https://trufflesuite.com/boxes/optimism/#compiling) and before the Migrating one (direct link does not work because of the typo).